### PR TITLE
Add meson.run command

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -12,6 +12,9 @@ prun spin docs
 
 SPIN_PYTHONPATH=$(spin run 'echo $PYTHONPATH')
 echo spin sees PYTHONPATH=\"${SPIN_PYTHONPATH}\"
-[[ $SPIN_PYTHONPATH == *"site-packages" ]]
+$ if [[ ${SPIN_PYTHONPATH} == "\$PYTHONPATH" ]]; then
+    echo -n "\!\!\!\!\n\nIf this says \$PYTHONPATH, that's an error\n\n\!\!\!\!\n"
+fi
+[[ ${SPIN_PYTHONPATH} == *"site-packages" ]]
 
 prun spin run python -c 'import sys; del sys.path[0]; import example_pkg; print(example_pkg.__version__)'

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -10,9 +10,10 @@ prun spin sdist
 prun spin example
 prun spin docs
 
+echo SPIN_PYTHONPATH=\$\(spin run 'echo $PYTHONPATH'\)
 SPIN_PYTHONPATH=$(spin run 'echo $PYTHONPATH')
 echo spin sees PYTHONPATH=\"${SPIN_PYTHONPATH}\"
-$ if [[ ${SPIN_PYTHONPATH} == "\$PYTHONPATH" ]]; then
+if [[ ${SPIN_PYTHONPATH} == "\$PYTHONPATH" ]]; then
     echo -n "\!\!\!\!\n\nIf this says \$PYTHONPATH, that's an error\n\n\!\!\!\!\n"
 fi
 [[ ${SPIN_PYTHONPATH} == *"site-packages" ]]

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -1,13 +1,17 @@
-set -xe
+set -e
 
-cd example_pkg
+prun() { echo "\$ $@" ; "$@" ; }
 
-spin build
-spin test
-spin sdist
-spin example
-spin docs
+prun cd example_pkg
 
-[[ $(spin run 'echo $PYTHONPATH') == *"site-packages" ]]
+prun spin build
+prun spin test
+prun spin sdist
+prun spin example
+prun spin docs
 
-spin run python -c 'import sys; del sys.path[0]; import example_pkg; print(example_pkg.__version__)'
+SPIN_PYTHONPATH=$(spin run 'echo $PYTHONPATH')
+echo spin sees PYTHONPATH=\"${SPIN_PYTHONPATH}\"
+[[ $SPIN_PYTHONPATH == *"site-packages" ]]
+
+prun spin run python -c 'import sys; del sys.path[0]; import example_pkg; print(example_pkg.__version__)'

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -1,0 +1,12 @@
+set -xe
+
+cd example_pkg
+
+spin build
+spin test
+spin sdist
+spin example
+
+[[ $(spin run 'echo $PYTHONPATH') != '$PYTHONPATH' ]]
+
+spin run python -c 'import sys; del sys.path[0]; import example_pkg'

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -5,11 +5,8 @@ prun() { echo "\$ $@" ; "$@" ; }
 prun cd example_pkg
 
 prun spin build
-prun spin test
-prun spin sdist
-prun spin example
-prun spin docs
 
+# Test spin run
 echo SPIN_PYTHONPATH=\$\(spin run 'echo $PYTHONPATH'\)
 SPIN_PYTHONPATH=$(spin run 'echo $PYTHONPATH')
 echo spin sees PYTHONPATH=\"${SPIN_PYTHONPATH}\"
@@ -17,5 +14,9 @@ if [[ ${SPIN_PYTHONPATH} == "\$PYTHONPATH" ]]; then
     echo -n "\!\!\!\!\n\nIf this says \$PYTHONPATH, that's an error\n\n\!\!\!\!\n"
 fi
 [[ ${SPIN_PYTHONPATH} == *"site-packages" ]]
-
 prun spin run python -c 'import sys; del sys.path[0]; import example_pkg; print(example_pkg.__version__)'
+
+prun spin test
+prun spin sdist
+prun spin example
+prun spin docs

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -10,4 +10,4 @@ spin docs
 
 [[ $(spin run 'echo $PYTHONPATH') != '$PYTHONPATH' ]]
 
-spin run python -c 'import sys; del sys.path[0]; import example_pkg'
+spin run python -c 'import sys; del sys.path[0]; import example_pkg; print(example_pkg.__version__)'

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -8,6 +8,6 @@ spin sdist
 spin example
 spin docs
 
-[[ $(spin run 'echo $PYTHONPATH') != '$PYTHONPATH' ]]
+[[ $(spin run 'echo $PYTHONPATH') == *"site-packages" ]]
 
 spin run python -c 'import sys; del sys.path[0]; import example_pkg; print(example_pkg.__version__)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Functional tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
+        env:
+          TERM: xterm-256color
         run: |
           set -xe
           cd example_pkg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,43 +39,20 @@ jobs:
           Remove-Item -Path C:\ProgramData\Chocolatey\bin\gcc.exe
           Remove-Item -Path C:\msys64 -Recurse -Force
           Remove-Item -Path "C:\Program Files\LLVM" -Recurse
+
       - name: Functional tests (Linux)
         if: matrix.os == 'ubuntu-latest'
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         env:
           TERM: xterm-256color
-        run: |
-          set -xe
-          cd example_pkg
-          spin build
-          spin test
-          spin sdist
-          spin example
-          spin run 'echo $PYTHONPATH'
-          spin run python -c 'import sys; del sys.path[0]; import example_pkg'
+        run: source .github/workflows/test.sh
+
       - name: Functional tests (MacOS)
         if: matrix.os == 'macos-latest'
         shell: bash
-        run: |
-          set -xe
-          cd example_pkg
-          spin build
-          spin test
-          spin sdist
-          spin example
-          spin run 'echo $PYTHONPATH'
-          spin run python -c 'import sys; del sys.path[0]; import example_pkg'
+        run: source .github/workflows/test.sh
+
       - name: Functional tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
-        env:
-          TERM: xterm-256color
-        run: |
-          set -xe
-          cd example_pkg
-          spin build
-          spin test
-          spin sdist
-          spin example
-          spin run 'echo $PYTHONPATH'
-          spin run python -c 'import sys; del sys.path[0]; import example_pkg'
+        run: source .github/workflows/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,8 @@ jobs:
   test_spin:
     strategy:
       matrix:
-        #python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
-        #os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.11"]
-        os: [windows-latest]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -34,9 +32,6 @@ jobs:
           PYTHONPATH: "."
         run: |
           pytest --pyargs spin
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: Functional tests (Linux)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,8 @@ jobs:
           spin example
           spin run 'echo $PYTHONPATH'
           spin run python -c 'import sys; del sys.path[0]; import example_pkg'
-      - name: Functional tests (other)
-        if: matrix.os != 'ubuntu-latest'
+      - name: Functional tests (MacOS)
+        if: matrix.os == 'macos-latest'
         shell: bash
         run: |
           set -x
@@ -64,4 +64,15 @@ jobs:
           spin sdist
           spin example
           spin run 'echo $PYTHONPATH'
+          spin run python -c 'import sys; del sys.path[0]; import example_pkg'
+      - name: Functional tests (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          Set-PSDebug -Trace 1
+          cd example_pkg
+          spin build
+          spin test
+          spin sdist
+          spin example
+          spin run 'echo %PYTHONPATH%'
           spin run python -c 'import sys; del sys.path[0]; import example_pkg'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           TERM: xterm-256color
         run: |
-          set -x
+          set -xe
           cd example_pkg
           spin build
           spin test
@@ -57,7 +57,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         shell: bash
         run: |
-          set -x
+          set -xe
           cd example_pkg
           spin build
           spin test
@@ -67,12 +67,13 @@ jobs:
           spin run python -c 'import sys; del sys.path[0]; import example_pkg'
       - name: Functional tests (Windows)
         if: matrix.os == 'windows-latest'
+        shell: bash
         run: |
-          Set-PSDebug -Trace 1
+          set -xe
           cd example_pkg
           spin build
           spin test
           spin sdist
           spin example
-          spin run 'echo %PYTHONPATH%'
+          spin run 'echo $PYTHONPATH'
           spin run python -c 'import sys; del sys.path[0]; import example_pkg'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           Remove-Item -Path C:\ProgramData\Chocolatey\bin\gcc.exe
           Remove-Item -Path C:\msys64 -Recurse -Force
           Remove-Item -Path "C:\Program Files\LLVM" -Recurse
-      - name: Functional tests (linux)
+      - name: Functional tests (Linux)
         if: matrix.os == 'ubuntu-latest'
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,13 +34,6 @@ jobs:
           PYTHONPATH: "."
         run: |
           pytest --pyargs spin
-      # - name: Patch Windows runner
-      #   if: matrix.os == 'windows-latest'
-      #   run: |
-      #     Remove-Item -Path C:\Strawberry -Recurse
-      #     Remove-Item -Path C:\ProgramData\Chocolatey\bin\gcc.exe
-      #     Remove-Item -Path C:\msys64 -Recurse -Force
-      #     Remove-Item -Path "C:\Program Files\LLVM" -Recurse
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
@@ -60,7 +53,4 @@ jobs:
       - name: Functional tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
-        env:
-          CC: clang-cl
-          CXX: clang-cl
         run: source .github/workflows/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,10 @@ jobs:
   test_spin:
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        #python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        #os: [ubuntu-latest, windows-latest, macos-latest]
+        python_version: ["3.11"]
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -32,13 +34,16 @@ jobs:
           PYTHONPATH: "."
         run: |
           pytest --pyargs spin
-      - name: Patch Windows runner
-        if: matrix.os == 'windows-latest'
-        run: |
-          Remove-Item -Path C:\Strawberry -Recurse
-          Remove-Item -Path C:\ProgramData\Chocolatey\bin\gcc.exe
-          Remove-Item -Path C:\msys64 -Recurse -Force
-          Remove-Item -Path "C:\Program Files\LLVM" -Recurse
+      # - name: Patch Windows runner
+      #   if: matrix.os == 'windows-latest'
+      #   run: |
+      #     Remove-Item -Path C:\Strawberry -Recurse
+      #     Remove-Item -Path C:\ProgramData\Chocolatey\bin\gcc.exe
+      #     Remove-Item -Path C:\msys64 -Recurse -Force
+      #     Remove-Item -Path "C:\Program Files\LLVM" -Recurse
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: Functional tests (Linux)
         if: matrix.os == 'ubuntu-latest'
@@ -55,4 +60,7 @@ jobs:
       - name: Functional tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
+        env:
+          CC: clang-cl
+          CXX: clang-cl
         run: source .github/workflows/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
           spin test
           spin sdist
           spin example
+          spin run 'echo $PYTHONPATH'
+          spin run python -c 'import sys; del sys.path[0]; import example_pkg'
       - name: Functional tests (other)
         if: matrix.os != 'ubuntu-latest'
         shell: bash
@@ -61,3 +63,5 @@ jobs:
           spin test
           spin sdist
           spin example
+          spin run 'echo $PYTHONPATH'
+          spin run python -c 'import sys; del sys.path[0]; import example_pkg'

--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ In `pyproject.toml`, instead of specifying the commands as a list, use the follo
   "spin.cmds.meson.test"
 ]
 "Environments" = [
-  "spin.cmds.meson.shell",
   "spin.cmds.meson.ipython",
-  "spin.cmds.meson.python"
+  "spin.cmds.meson.run"
 ]
 ```
 
@@ -63,9 +62,8 @@ Build:
   test   🔧 Run tests
 
 Environments:
-  shell    💻 Launch shell with PYTHONPATH set
   ipython  💻 Launch IPython shell with PYTHONPATH set
-  python   🐍 Launch Python shell with PYTHONPATH set
+  run      🏁 Run a shell command with PYTHONPATH set.
 ```
 
 ## Running
@@ -90,6 +88,8 @@ python -m spin
   python   🐍 Launch Python shell with PYTHONPATH set
   shell    💻 Launch shell with PYTHONPATH set
   test     🔧 Run pytest
+  run      🏁 Run a shell command with PYTHONPATH set.
+
 ```
 
 ### [Build](https://pypa-build.readthedocs.io/en/stable/) (PEP 517 builder)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Build:
 
 Environments:
   ipython  💻 Launch IPython shell with PYTHONPATH set
-  run      🏁 Run a shell command with PYTHONPATH set.
+  run      🏁 Run a shell command with PYTHONPATH set
 ```
 
 ## Running
@@ -88,7 +88,7 @@ python -m spin
   python   🐍 Launch Python shell with PYTHONPATH set
   shell    💻 Launch shell with PYTHONPATH set
   test     🔧 Run pytest
-  run      🏁 Run a shell command with PYTHONPATH set.
+  run      🏁 Run a shell command with PYTHONPATH set
   docs     📖 Build Sphinx documentation
 ```
 
@@ -97,7 +97,7 @@ python -m spin
 `spin` was started with Meson in mind, but we're working on expanding commands for PEP 517 `build`.
 
 ```
-  sdist    📦 Build a source distribution in `dist/`.
+  sdist    📦 Build a source distribution in `dist/`
 ```
 
 ## 🧪 Custom commands

--- a/example_pkg/example_pkg/__init__.py
+++ b/example_pkg/example_pkg/__init__.py
@@ -1,1 +1,3 @@
 from ._core import echo
+
+__version__ = "0.0.0dev0"

--- a/example_pkg/pyproject.toml
+++ b/example_pkg/pyproject.toml
@@ -33,6 +33,7 @@ package = 'example_pkg'
 "Environments" = [
   "spin.cmds.meson.shell",
   "spin.cmds.meson.ipython",
-  "spin.cmds.meson.python"
+  "spin.cmds.meson.python",
+  "spin.cmds.meson.run"
 ]
 "Extensions" = [".spin/cmds.py:example"]

--- a/spin/cmds/build.py
+++ b/spin/cmds/build.py
@@ -5,5 +5,5 @@ from .util import run
 
 @click.command()
 def sdist():
-    """📦 Build a source distribution in `dist/`."""
+    """📦 Build a source distribution in `dist/`"""
     run(["python", "-m", "build", ".", "--sdist"])

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -187,7 +187,11 @@ def test(ctx, pytest_args):
 
     # Sanity check that library built properly
     if sys.version_info[:2] >= (3, 11):
-        run([sys.executable, "-P", "-c", f"import {package}"])
+        p = _run([sys.executable, "-P", "-c", f"import {package}"], sys_exit=False)
+        if p.returncode != 0:
+            print(f"As a sanity check, we tried to import {package}.")
+            print("Stopping. Please investigate the build error.")
+            sys.exit(1)
 
     print(f'$ export PYTHONPATH="{site_path}"')
     _run(

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -12,7 +12,7 @@ from .util import run as _run, get_config, get_commands
 install_dir = "build-install"
 
 
-def _set_pythonpath():
+def _set_pythonpath(quiet=False):
     site_packages = _get_site_packages()
     env = os.environ
 
@@ -21,7 +21,10 @@ def _set_pythonpath():
     else:
         env["PYTHONPATH"] = site_packages
 
-    click.secho(f'$ export PYTHONPATH="{site_packages}"', bold=True, fg="bright_blue")
+    if not quiet:
+        click.secho(
+            f'$ export PYTHONPATH="{site_packages}"', bold=True, fg="bright_blue"
+        )
 
     return env["PYTHONPATH"]
 
@@ -283,7 +286,7 @@ def run(args):
     if shell:
         args = args[0]
 
-    _set_pythonpath()
+    _set_pythonpath(quiet=True)
     _run(args, echo=False, shell=shell)
 
 

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -289,15 +289,16 @@ def run(args):
     if not len(args) > 0:
         raise RuntimeError("No command given")
 
-    shell = len(args) == 1
-    if shell:
-        args = args[0]
-
     is_posix = sys.platform in ("linux", "darwin")
+    shell = len(args) == 1
+
     if not is_posix:
         # On Windows, we're going to try to use bash
         args = ["bash", "-c"] + args
         shell = True
+    else:
+        if shell:
+            args = args[0]
 
     _set_pythonpath(quiet=True)
     _run(args, echo=False, shell=shell)

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -278,10 +278,13 @@ def run(args):
     spin run 'echo $PYTHONPATH'
     spin run python -c 'import sys; del sys.path[0]; import mypkg'
 
-    If you'd like to expand a shell variable, like `$PYTHONPATH` in the example
+    If you'd like to expand shell variables, like `$PYTHONPATH` in the example
     above, you need to provide a single, quoted command to `run`:
 
     spin run 'echo $SHELL && echo $PWD'
+
+    On Windows, all commands are run via Bash.
+    Install Git for Windows if you don't have Bash already.
     """
     if not len(args) > 0:
         raise RuntimeError("No command given")
@@ -289,6 +292,12 @@ def run(args):
     shell = len(args) == 1
     if shell:
         args = args[0]
+
+    is_posix = sys.platform in ("linux", "darwin")
+    if not is_posix:
+        # On Windows, we're going to try to use bash
+        args = ["bash", "-c"] + args
+        shell = True
 
     _set_pythonpath(quiet=True)
     _run(args, echo=False, shell=shell)

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -262,12 +262,16 @@ def run(args):
     spin run python -c 'import sys; del sys.path[0]; import mypkg'
 
     If you'd like to expand a shell variable, like `$PYTHONPATH` in the example
-    above, you need to provide a single, quoted command to `run`.
+    above, you need to provide a single, quoted command to `run`:
+
+    spin run 'echo $SHELL && echo $PWD'
     """
     if not len(args) > 0:
         raise RuntimeError("No command given")
 
     shell = len(args) == 1
+    if shell:
+        args = args[0]
 
     _set_pythonpath()
     _run(args, echo=False, shell=shell)

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -254,12 +254,15 @@ def python(python_args):
 @click.command(context_settings={"ignore_unknown_options": True})
 @click.argument("args", nargs=-1)
 def run(args):
-    """🏁 Run a shell command with PYTHONPATH set.
+    """🏁 Run a shell command with PYTHONPATH set
 
     \b
     spin run make
     spin run 'echo $PYTHONPATH'
     spin run python -c 'import sys; del sys.path[0]; import mypkg'
+
+    If you'd like to expand a shell variable, like `$PYTHONPATH` in the example
+    above, you need to provide a single, quoted command to `run`.
     """
     if not len(args) > 0:
         raise RuntimeError("No command given")

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -283,7 +283,7 @@ def run(args):
 
     spin run 'echo $SHELL && echo $PWD'
 
-    On Windows, all commands are run via Bash.
+    On Windows, all shell commands are run via Bash.
     Install Git for Windows if you don't have Bash already.
     """
     if not len(args) > 0:
@@ -291,14 +291,12 @@ def run(args):
 
     is_posix = sys.platform in ("linux", "darwin")
     shell = len(args) == 1
+    if shell:
+        args = args[0]
 
-    if not is_posix:
+    if shell and not is_posix:
         # On Windows, we're going to try to use bash
-        args = ["bash", "-c"] + args
-        shell = True
-    else:
-        if shell:
-            args = args[0]
+        args = ["bash", "-c", args]
 
     _set_pythonpath(quiet=True)
     _run(args, echo=False, shell=shell)

--- a/spin/cmds/util.py
+++ b/spin/cmds/util.py
@@ -19,6 +19,7 @@ def run(
         Change to this directory before execution.
     replace : bool
         Whether to replace the current process.
+        Note that this has no effect on Windows.
     sys_exit : bool
         Whether to exit if the shell command returns with error != 0.
     output : bool
@@ -46,7 +47,7 @@ def run(
         output_kwargs = {"stdout": subprocess.PIPE, "stderr": subprocess.STDOUT}
         kwargs = {**output_kwargs, **kwargs}
 
-    if replace:
+    if replace and (sys.platform in ("linux", "darwin")):
         os.execvp(cmd[0], cmd)
         print(f"Failed to launch `{cmd}`")
         sys.exit(-1)


### PR DESCRIPTION
The command operates in two modes. If a single argument is given, it uses subprocess's `shell=True`, so you can use shell substitution, as in:

  spin run 'echo $PYTHONPATH'

If multiple arguments are given, it uses standard execution, e.g.:

  spin run python -c 'import sys; del sys.path[0]; import example_pkg'

Enabling `shell=True` for the latter would incorrectly disregarded the quoting.

Closes #69 