### PR TITLE
Import importlib.util explicitly

### DIFF
--- a/spin/__main__.py
+++ b/spin/__main__.py
@@ -2,6 +2,7 @@ import collections
 import os
 import sys
 import importlib
+import importlib.util
 from glob import glob
 
 import click


### PR DESCRIPTION
Seems to be needed on some Python 3.10