### PR TITLE
Allow custom Meson CLI path

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ def build(ctx, meson_args, jobs=None, clean=False, verbose=False, custom_arg=Fal
     # - https://click.palletsprojects.com/en/8.1.x/api/#click.Context.invoke
 ```
 
+### Advanced: override Meson CLI
+
+Some packages use a vendored version of Meson. The path to a custom
+Meson CLI can be set in `pyproject.toml`:
+
+```
+[tool.spin.meson]
+cli = 'path/to/custom/meson'
+```
+
 ## History
 
 The `dev.py` tool was [proposed for SciPy](https://github.com/scipy/scipy/issues/15489) by Ralf Gommers and [implemented](https://github.com/scipy/scipy/pull/15959) by Sayantika Banik, Eduardo Naufel Schettino, and Ralf Gommers (also see [Sayantika's blog post](https://labs.quansight.org/blog/the-evolution-of-the-scipy-developer-cli)).

--- a/example_pkg/.gitignore
+++ b/example_pkg/.gitignore
@@ -2,3 +2,4 @@ build
 build-install
 .mesonpy-native-file.ini
 dist/
+doc/_build

--- a/spin/__main__.py
+++ b/spin/__main__.py
@@ -1,4 +1,3 @@
-import collections
 import importlib
 import importlib.util
 import os
@@ -8,6 +7,7 @@ import click
 
 from spin import cmds as _cmds
 from spin.color_format import ColorHelpFormatter
+from spin.containers import DotDict
 from spin.sectioned_help import SectionedHelpGroup
 
 if sys.version_info >= (3, 11):
@@ -16,28 +16,6 @@ else:
     import tomli as tomllib
 
 click.Context.formatter_class = ColorHelpFormatter
-
-
-class DotDict(collections.UserDict):
-    def __getitem__(self, key):
-        subitem = self.data
-        for subkey in key.split("."):
-            try:
-                subitem = subitem[subkey]
-            except KeyError:
-                raise KeyError(f"`{key}` not found in configuration") from None
-        return subitem
-
-    # Fix for Python 3.12
-    # See https://github.com/python/cpython/issues/105524
-    def __contains__(self, key):
-        subitem = self.data
-        for subkey in key.split("."):
-            try:
-                subitem = subitem[subkey]
-            except KeyError:
-                return False
-        return True
 
 
 def main():

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -11,6 +11,13 @@ from .util import run as _run
 install_dir = "build-install"
 
 
+# Allow specification of meson binary in configuration
+# This is necessary for packages like NumPy that vendor meson
+def _meson_cli():
+    cfg = get_config()
+    return os.path.expanduser(cfg.get("tool.spin.meson.cli", "meson"))
+
+
 def _set_pythonpath(quiet=False):
     site_packages = _get_site_packages()
     env = os.environ
@@ -67,7 +74,7 @@ def _get_site_packages():
 
 def _meson_version():
     try:
-        p = _run(["meson", "--version"], output=False, echo=False)
+        p = _run([_meson_cli(), "--version"], output=False, echo=False)
         return p.stdout.decode("ascii").strip()
     except:
         pass
@@ -104,7 +111,7 @@ def build(meson_args, jobs=None, clean=False, verbose=False):
     spin build -- -Dbuildtype=debug
     """
     build_dir = "build"
-    setup_cmd = ["meson", "setup", build_dir, "--prefix=/usr"] + list(meson_args)
+    setup_cmd = [_meson_cli(), "setup", build_dir, "--prefix=/usr"] + list(meson_args)
 
     if clean:
         print(f"Removing `{build_dir}`")
@@ -129,10 +136,10 @@ def build(meson_args, jobs=None, clean=False, verbose=False):
 
         # Any other conditions that warrant a reconfigure?
 
-    p = _run(["meson", "compile", "-C", build_dir], sys_exit=False)
+    p = _run([_meson_cli(), "compile", "-C", build_dir], sys_exit=False)
     p = _run(
         [
-            "meson",
+            _meson_cli(),
             "install",
             "--only-changed",
             "-C",

--- a/spin/cmds/util.py
+++ b/spin/cmds/util.py
@@ -13,6 +13,8 @@ def run(
 
     Parameters
     ----------
+    cmd : list of str
+        Command to execute.
     cwd : str
         Change to this directory before execution.
     replace : bool

--- a/spin/containers.py
+++ b/spin/containers.py
@@ -1,0 +1,23 @@
+import collections
+
+
+class DotDict(collections.UserDict):
+    def __getitem__(self, key):
+        subitem = self.data
+        for subkey in key.split("."):
+            try:
+                subitem = subitem[subkey]
+            except KeyError:
+                raise KeyError(f"`{key}` not found in configuration") from None
+        return subitem
+
+    # Fix for Python 3.12
+    # See https://github.com/python/cpython/issues/105524
+    def __contains__(self, key):
+        subitem = self.data
+        for subkey in key.split("."):
+            try:
+                subitem = subitem[subkey]
+            except KeyError:
+                return False
+        return True

--- a/spin/tests/test_meson.py
+++ b/spin/tests/test_meson.py
@@ -103,8 +103,14 @@ def test_path_discovery(monkeypatch):
 
 
 def test_meson_cli_discovery(monkeypatch):
-    config = DotDict({"tool": {"spin": {"meson": {"cli": "~/envs/py311/bin/meson"}}}})
+    config0 = DotDict({"tool": {"spin": {"meson": {"cli": "~/envs/py311/bin/meson"}}}})
+    config1 = DotDict(
+        {"tool": {"spin": {"meson": {"cli": "~/envs/py311/bin/meson.py"}}}}
+    )
 
     with monkeypatch.context() as m:
-        m.setattr(meson, "get_config", lambda: config)
-        assert meson._meson_cli() == os.path.expanduser("~/envs/py311/bin/meson")
+        m.setattr(meson, "get_config", lambda: config0)
+        assert meson._meson_cli()[0] == os.path.expanduser("~/envs/py311/bin/meson")
+
+        m.setattr(meson, "get_config", lambda: config1)
+        assert meson._meson_cli()[0] == sys.executable

--- a/spin/tests/test_meson.py
+++ b/spin/tests/test_meson.py
@@ -7,6 +7,7 @@ from os.path import normpath
 import pytest
 
 from spin.cmds import meson
+from spin.containers import DotDict
 
 
 def make_paths(root, paths):
@@ -99,3 +100,11 @@ def test_path_discovery(monkeypatch):
             )
             with pytest.raises(FileNotFoundError):
                 meson._get_site_packages()
+
+
+def test_meson_cli_discovery(monkeypatch):
+    config = DotDict({"tool": {"spin": {"meson": {"cli": "~/envs/py311/bin/meson"}}}})
+
+    with monkeypatch.context() as m:
+        m.setattr(meson, "get_config", lambda: config)
+        assert meson._meson_cli() == os.path.expanduser("~/envs/py311/bin/meson")


### PR DESCRIPTION
@rgommers This PR allows setting the Meson CLI in `pyproject.toml`. Do you think that would address NumPy's need?