### PR TITLE
ENH: Added coverage option for `test` command

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -166,9 +166,10 @@ def _get_configured_command(command_name):
 @click.command()
 @click.argument("pytest_args", nargs=-1)
 @click.option(
+    "-c",
     "--coverage",
     is_flag=True,
-    help="Report coverage of project code. HTML output goes under build/coverage",
+    help="Generate a coverage report of executed tests. An HTML copy of the report is written to `build/coverage`.",
 )
 @click.pass_context
 def test(ctx, pytest_args, coverage=False):
@@ -243,12 +244,13 @@ def test(ctx, pytest_args, coverage=False):
 
     if coverage:
         coverage_dir = os.path.join(os.getcwd(), "build/coverage/")
-        print(f"Removing `{coverage_dir}`")
         if os.path.isdir(coverage_dir):
+            print(f"Removing `{coverage_dir}`")
             shutil.rmtree(coverage_dir)
         os.makedirs(coverage_dir)
         pytest_args = [
             *pytest_args,
+            "--cov-report=term",
             f"--cov-report=html:{coverage_dir}",
             f"--cov={package}",
         ]

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -165,8 +165,13 @@ def _get_configured_command(command_name):
 
 @click.command()
 @click.argument("pytest_args", nargs=-1)
+@click.option(
+    "--coverage",
+    is_flag=True,
+    help="Report coverage of project code. HTML output goes under build/coverage",
+)
 @click.pass_context
-def test(ctx, pytest_args):
+def test(ctx, pytest_args, coverage=False):
     """🔧 Run tests
 
     PYTEST_ARGS are passed through directly to pytest, e.g.:
@@ -235,6 +240,18 @@ def test(ctx, pytest_args):
             print(f"As a sanity check, we tried to import {package}.")
             print("Stopping. Please investigate the build error.")
             sys.exit(1)
+
+    if coverage:
+        coverage_dir = os.path.join(os.getcwd(), "build/coverage/")
+        print(f"Removing `{coverage_dir}`")
+        if os.path.isdir(coverage_dir):
+            shutil.rmtree(coverage_dir)
+        os.makedirs(coverage_dir)
+        pytest_args = [
+            *pytest_args,
+            f"--cov-report=html:{coverage_dir}",
+            f"--cov={package}",
+        ]
 
     print(f'$ export PYTHONPATH="{site_path}"')
     _run(


### PR DESCRIPTION
### Changes
- ENH: Added coverage option for `test` command

### Testing
```
spin test --coverage -- -vv
```
Output:
```
...
Coverage HTML written to dir /home/ganesh/os/devpy/example_pkg/build/coverage/
...
```

```
~/os/devpy/example_pkg (coverage) » ls build/coverage                                                                                                                 130 ↵ ganesh@ganesh-MS-7B86
coverage_html.js  d_8d15ffec5afca27f___init___py.html  d_b2ad4cdda83343df_test_core_py.html  favicon_32.png  index.html  keybd_closed.png  keybd_open.png  status.json  style.css
```