### PR TITLE
Drop mention of old devpy name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 ## A developer tool for scientific Python libraries
 
-**NOTE:** If you are looking for `devpy`, this is it! We had to rename
-the package to publish it on PyPi.
-
 Developers need to memorize a whole bunch of magic command-line incantations.
 And these incantations change from time to time!
 Typically, their lives are made simpler by a Makefile, but Makefiles can be convoluted, are not written in Python, and are hard to extend.


### PR DESCRIPTION
I think it has been long enough to drop this reference to the old name. It wasn't called devpy for long and at some point it will be more confusing than helpful to mention we briefly used another name.