### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test_spin:
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "spin"
 version = "0.8rc0.dev0"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 description = "Developer tool for scientific Python libraries"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -16,7 +16,6 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -50,7 +49,7 @@ filterwarnings = [
 
 [tool.ruff]
 line-length = 88
-target-version = "py37"
+target-version = "py38"
 select = [
     "C",
     "E",


### PR DESCRIPTION
Python 3.7 eol as 2023-06-27. According to SPEC 0, we recommend projects drop 3.9 in early October. I think we should support 3.8 and 3.9 a bit longer since we aren't a library and instead a developer tool. But I think dropping 3.7 now seems reasonable.