### PR TITLE
Fix unclosed file warning on debug python

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -96,7 +96,8 @@ def _meson_version():
 def _meson_version_configured():
     try:
         meson_info_fn = os.path.join("build", "meson-info", "meson-info.json")
-        meson_info = json.load(open(meson_info_fn))
+        with open(meson_info_fn) as f:
+            meson_info = json.load(f)
         return meson_info["meson_version"]["full"]
     except:
         pass


### PR DESCRIPTION
Debug builds of python have a warning about this that displays every time I run numpy's spin config:

```
nathan at rous in ~/Documents/numpy on rename-numpy-core!
± python -m spin test
Invoking `build` prior to running tests:
/home/nathan/.pyenv/versions/3.10.9-debug/lib/python3.10/site-packages/spin/cmds/meson.py:99: ResourceWarning: unclosed file <_io.TextIOWrapper name='build/meson-info/meson-info.json' mode='r' encoding='UTF-8'>
  meson_info = json.load(open(meson_info_fn))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```