### PR TITLE
Add `gcov` flags for build

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -16,7 +16,26 @@ prun spin --version
 
 ptest build command runs
 pip install meson-python ninja
-prun spin build
+
+
+# Test spin build + debug builds
+echo -e "${MAGENTA}Creating debug builds${NORMAL}"
+prun spin build --gcov
+echo -e "${MAGENTA}Did the build folder get generated?${NORMAL}"
+if [ ! -d "build" ] || [ ! -d "build-install" ]; then
+    echo -e "${RED}build and/or build-install folders did not get generated${NORMAL}"
+    exit 1
+else
+    echo "Yes"
+fi
+echo -e "${MAGENTA}Does the debug build contain gcov files?${NORMAL}"
+matching_files=$(find . -type f -name "*.gc*")
+if [ -z "$matching_files" ]; then
+    echo -e "${RED}Debug files did not get generated${NORMAL}"
+    exit 1
+else
+    echo "Yes"
+fi
 
 ptest Does spin expand \$PYTHONPATH?
 SPIN_PYTHONPATH=$(spin run 'echo $PYTHONPATH')

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -133,9 +133,18 @@ def _meson_version_configured():
 @click.option(
     "--gcov",
     is_flag=True,
-    help="Enable C code coverage via `gcov`. "
-    "Reports can be generated using `ninja coverage*` commands. "
-    "See https://mesonbuild.com/howtox.html#producing-a-coverage-report",
+    help="""Enable C code coverage via `gcov`.
+
+    The meson-generated `build/build.ninja` has targets for compiling
+    coverage reports.
+
+    E.g., to build an HTML report, in the `build` directory run
+     `ninja coverage-html`.
+
+    To see a list all supported formats, run
+    `ninja -t targets | grep coverage-`.
+
+    Also see https://mesonbuild.com/howtox.html#producing-a-coverage-report.""",
 )
 @click.argument("meson_args", nargs=-1)
 def build(meson_args, jobs=None, clean=False, verbose=False, gcov=False, quiet=False):

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -133,7 +133,9 @@ def _meson_version_configured():
 @click.option(
     "--gcov",
     is_flag=True,
-    help="Enable C code coverage via gcov (requires GCC)",
+    help="Enable C code coverage via `gcov`. "
+    "Reports can be generated using `ninja coverage*` commands. "
+    "See https://mesonbuild.com/howtox.html#producing-a-coverage-report",
 )
 @click.argument("meson_args", nargs=-1)
 def build(meson_args, jobs=None, clean=False, verbose=False, gcov=False, quiet=False):
@@ -248,7 +250,9 @@ Which tests to run. Can be a module, function, class, or method:
 @click.option(
     "--gcov",
     is_flag=True,
-    help="Enable C code coverage via gcov (requires GCC). gcov output goes to build/**/*.gc*",
+    help="Enable C code coverage via `gcov`. `gcov` output goes to `build/**/*.gc*`. "
+    "Reports can be generated using `ninja coverage*` commands. "
+    "See https://mesonbuild.com/howtox.html#producing-a-coverage-report",
 )
 @click.pass_context
 def test(ctx, pytest_args, n_jobs, tests, verbose, coverage=False, gcov=False):

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -131,14 +131,12 @@ def _meson_version_configured():
     "-v", "--verbose", is_flag=True, help="Print detailed build and installation output"
 )
 @click.option(
-    "--gcov-build",
+    "--gcov",
     is_flag=True,
     help="Enable C code coverage via gcov (requires GCC)",
 )
 @click.argument("meson_args", nargs=-1)
-def build(
-    meson_args, jobs=None, clean=False, verbose=False, gcov_build=False, quiet=False
-):
+def build(meson_args, jobs=None, clean=False, verbose=False, gcov=False, quiet=False):
     """🔧 Build package with Meson/ninja and install
 
     MESON_ARGS are passed through e.g.:
@@ -158,7 +156,7 @@ def build(
     """
     build_dir = "build"
 
-    if gcov_build:
+    if gcov:
         meson_args = list(meson_args) + ["-Db_coverage=true"]
 
     setup_cmd = _meson_cli() + ["setup", build_dir, "--prefix=/usr"] + list(meson_args)
@@ -299,7 +297,7 @@ def test(ctx, pytest_args, n_jobs, tests, verbose, coverage=False, gcov=False):
         click.secho(
             "Invoking `build` prior to running tests:", bold=True, fg="bright_green"
         )
-        ctx.invoke(build_cmd, gcov_build=gcov)
+        ctx.invoke(build_cmd, gcov=gcov)
 
     package = cfg.get("tool.spin.package", None)
     if (not pytest_args) and (not tests):

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -166,11 +166,12 @@ def build(meson_args, jobs=None, clean=False, verbose=False, gcov=False, quiet=F
       CFLAGS="-O0 -g" spin build
     """
     build_dir = "build"
+    meson_args = list(meson_args)
 
     if gcov:
-        meson_args = list(meson_args) + ["-Db_coverage=true"]
+        meson_args = meson_args + ["-Db_coverage=true"]
 
-    setup_cmd = _meson_cli() + ["setup", build_dir, "--prefix=/usr"] + list(meson_args)
+    setup_cmd = _meson_cli() + ["setup", build_dir, "--prefix=/usr"] + meson_args
 
     if clean:
         print(f"Removing `{build_dir}`")

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -130,8 +130,15 @@ def _meson_version_configured():
 @click.option(
     "-v", "--verbose", is_flag=True, help="Print detailed build and installation output"
 )
+@click.option(
+    "--gcov-build",
+    is_flag=True,
+    help="Enable C code coverage via gcov (requires GCC)",
+)
 @click.argument("meson_args", nargs=-1)
-def build(meson_args, jobs=None, clean=False, verbose=False, quiet=False):
+def build(
+    meson_args, jobs=None, clean=False, verbose=False, gcov_build=False, quiet=False
+):
     """🔧 Build package with Meson/ninja and install
 
     MESON_ARGS are passed through e.g.:
@@ -150,6 +157,10 @@ def build(meson_args, jobs=None, clean=False, verbose=False, quiet=False):
       CFLAGS="-O0 -g" spin build
     """
     build_dir = "build"
+
+    if gcov_build:
+        meson_args = list(meson_args) + ["-Db_coverage=true"]
+
     setup_cmd = _meson_cli() + ["setup", build_dir, "--prefix=/usr"] + list(meson_args)
 
     if clean:
@@ -236,8 +247,13 @@ Which tests to run. Can be a module, function, class, or method:
     is_flag=True,
     help="Generate a coverage report of executed tests. An HTML copy of the report is written to `build/coverage`.",
 )
+@click.option(
+    "--gcov",
+    is_flag=True,
+    help="Enable C code coverage via gcov (requires GCC). gcov output goes to build/**/*.gc*",
+)
 @click.pass_context
-def test(ctx, pytest_args, n_jobs, tests, verbose, coverage=False):
+def test(ctx, pytest_args, n_jobs, tests, verbose, coverage=False, gcov=False):
     """🔧 Run tests
 
     PYTEST_ARGS are passed through directly to pytest, e.g.:
@@ -283,7 +299,7 @@ def test(ctx, pytest_args, n_jobs, tests, verbose, coverage=False):
         click.secho(
             "Invoking `build` prior to running tests:", bold=True, fg="bright_green"
         )
-        ctx.invoke(build_cmd)
+        ctx.invoke(build_cmd, gcov_build=gcov)
 
     package = cfg.get("tool.spin.package", None)
     if (not pytest_args) and (not tests):


### PR DESCRIPTION
### Changes
- Added `gcov` flags for build

### Related
This is needed to generate `gcov` reports for NumPy. xref: https://github.com/numpy/numpy/pull/24992

### Testing
In NumPy, after merging of https://github.com/numpy/numpy/pull/24992:

![image](https://github.com/scientific-python/spin/assets/20969920/1ed0887f-3875-4846-a9ae-47ad5aab39c4)

1. `spin test --coverage --gcov`
2. `spin test --generate-lcov-html`
```
~/os/numpy (bld_24080_coverage) » spin test --generate-lcov-html                                                                                                            ganesh@ganesh-MS-7B86
Deleting old HTML coverage report...
Generating HTML coverage report...
$ ninja coverage-html -C build
Coverage report generated successfully and written to /home/ganesh/os/numpy/build/meson-logs/coveragereport/index.html
```

---

Other error handling
1. `spin build`
2. `spin test --generate-lcov-html`
```
~/os/numpy (bld_24080_coverage) » spin test --generate-lcov-html                                                                                                            ganesh@ganesh-MS-7B86
Error: GCOV files missing... Cannot generate coverage reports. Coverage reports can be generated by `spin test --coverage --gcov`

```

---

### Notes
Although I verified it with NumPy, ~needs a bit more testing which I'll do in a while~
```
~/os/numpy (bld_24080_coverage*) » find . -name \*.gcno | wc -l                              ganesh@ganesh-MS-7B86
204
```