### PR TITLE
Detect when a conflicting editable install exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 dependencies = [
   "click",
   "tomli; python_version < '3.11'",
-  "colorama; platform_system == 'Windows'"
+  "colorama; platform_system == 'Windows'",
+  "importlib_metadata >= 7"
 ]
 dynamic = ['version']
 

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -36,6 +36,26 @@ def _set_pythonpath(quiet=False):
     site_packages = _get_site_packages()
     env = os.environ
 
+    cfg = get_config()
+    package = cfg.get("tool.spin.package", None)
+    if package:
+        import importlib_metadata
+
+        try:
+            dist = importlib_metadata.Distribution.from_name(package)
+            if dist.origin.dir_info.editable:
+                click.secho(
+                    f"Warning! An editable installation of `{package}` was detected.",
+                    fg="bright_red",
+                )
+                click.secho("Spin commands will pick up that version.", fg="bright_red")
+                click.secho(
+                    f"Try removing the other installation with `pip uninstall {package}`.",
+                    fg="bright_red",
+                )
+        except importlib_metadata.PackageNotFoundError:
+            pass
+
     if "PYTHONPATH" in env:
         env["PYTHONPATH"] = f"{site_packages}{os.pathsep}{env['PYTHONPATH']}"
     else:

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -43,7 +43,7 @@ def _set_pythonpath(quiet=False):
 
         try:
             dist = importlib_metadata.Distribution.from_name(package)
-            if dist.origin.dir_info.editable:
+            if getattr(dist.origin.dir_info, "editable", False):
                 click.secho(
                     f"Warning! An editable installation of `{package}` was detected.",
                     fg="bright_red",


### PR DESCRIPTION
Closes #143 

I'd like to check with @rgommers that this won't impact the workflow of those using editable packages. Do those users also use spin? If so, should we more explicitly accommodate editable installs, and simply skip the build step?