### PR TITLE
Add ``--gcov-report`` flag to ``spin test``

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gdb
+          sudo apt-get install -y gdb lcov
       - name: Tests PyTest
         run: |
           pipx run nox --forcecolor -s test

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ fc-cache -f -v
 `spin` tests are invoked using:
 
 ```
-nox -s tests
+nox -s test
 ```
 
 ## History

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,5 +3,5 @@ import nox
 
 @nox.session
 def test(session: nox.Session) -> None:
-    session.install(".", "pytest", "build", "meson-python", "ninja")
+    session.install(".", "pytest", "build", "meson-python", "ninja", "gcovr")
     session.run("pytest", "spin", *session.posargs)

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -300,7 +300,7 @@ Which tests to run. Can be a module, function, class, or method:
     "--gcov",
     is_flag=True,
     help="Enable C code coverage via `gcov`. `gcov` output goes to `build/**/*.gc*`. "
-    "Reports can be generated using `spin test --generate-gcov-report *` command. "
+    "Reports can be generated using `spin test --gcov-report *` command. "
     "See https://mesonbuild.com/howtox.html#producing-a-coverage-report",
 )
 @click.pass_context

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -286,7 +286,7 @@ Which tests to run. Can be a module, function, class, or method:
 )
 @click.option("--verbose", "-v", is_flag=True, default=False)
 @click.option(
-    "--generate-gcov-report",
+    "--gcov-report",
     type=click.Choice(GcovReports),
     help="Generate a coverage report for C Code and exit",
 )
@@ -310,7 +310,7 @@ def test(
     n_jobs,
     tests,
     verbose,
-    generate_gcov_report,
+    gcov_report,
     coverage=False,
     gcov=False,
 ):
@@ -356,18 +356,18 @@ def test(
 
     For more, see `pytest --help`.
     """  # noqa: E501
-    if generate_gcov_report:
+    if gcov_report:
         # Verify the tools are present
         click.secho(
             "Verifying installed packages for generating coverage reports...",
             bold=True,
             fg="bright_yellow",
         )
-        _check_coverage_tool_installation(generate_gcov_report)
+        _check_coverage_tool_installation(gcov_report)
 
         # Generate report
         click.secho(
-            f"Generating {generate_gcov_report.value} coverage report...",
+            f"Generating {gcov_report.value} coverage report...",
             bold=True,
             fg="bright_yellow",
         )
@@ -376,7 +376,7 @@ def test(
                 "ninja",
                 "-C",
                 build_dir,
-                f"coverage-{generate_gcov_report.value.lower()}",
+                f"coverage-{gcov_report.value.lower()}",
             ],
             output=False,
         )

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import sys
+from pathlib import Path
 
 import click
 
@@ -146,6 +147,13 @@ def _check_coverage_tool_installation(coverage_type: GcovReports):
     if not (os.path.exists(build_dir)):
         raise click.ClickException(
             "`build` folder not found, cannot generate coverage reports. "
+            "Generate coverage artefacts by running `spin test --gcov`"
+        )
+
+    debug_files = Path(build_dir).rglob("*.gcno")
+    if len(list(debug_files)) == 0:
+        raise click.ClickException(
+            "debug build not found, cannot generate coverage reports. "
             "Generate coverage artefacts by running `spin test --gcov`"
         )
 

--- a/spin/tests/test_build_cmds.py
+++ b/spin/tests/test_build_cmds.py
@@ -55,6 +55,21 @@ def test_coverage_reports(report_type, output_file):
     ), f"coverage report not generated for gcov build ({report_type})"
 
 
+@pytest.mark.parametrize(
+    "command,error_message",
+    [
+        ("", "`build` folder not found"),
+        ("build", "debug build not found"),
+        ("test", "debug build not found"),
+    ],
+)
+def test_no_debug_coverage_attempt(command, error_message):
+    """Does gcov report throw error in case of missing debug files"""
+    spin(command) if command else None
+    output = spin("test", "--gcov-report", "html", sys_exit=False)
+    assert error_message in stderr(output)
+
+
 def test_expand_pythonpath():
     """Does an $ENV_VAR get expanded in `spin run`?"""
     output = spin("run", "echo $PYTHONPATH")

--- a/spin/tests/test_build_cmds.py
+++ b/spin/tests/test_build_cmds.py
@@ -27,6 +27,34 @@ def test_debug_builds():
     assert len(list(debug_files)) != 0, "debug files not generated for gcov build"
 
 
+def test_coverage_builds():
+    """Does gcov test generate coverage files?"""
+    spin("test", "--gcov")
+
+    coverage_files = Path(".").rglob("*.gcda")
+    assert len(list(coverage_files)) != 0, "coverage files not generated for gcov build"
+
+
+@pytest.mark.parametrize(
+    "report_type,output_file",
+    [
+        ("html", Path("coveragereport/index.html")),
+        ("xml", Path("coverage.xml")),
+        ("text", Path("coverage.txt")),
+        ("sonarqube", Path("sonarqube.xml")),
+    ],
+)
+def test_coverage_reports(report_type, output_file):
+    """Does gcov test generate coverage reports?"""
+    spin("test", "--gcov")
+    spin("test", "--gcov-report", report_type)
+
+    coverage_report = Path("./build/meson-logs", output_file)
+    assert (
+        coverage_report.exists()
+    ), f"coverage report not generated for gcov build ({report_type})"
+
+
 def test_expand_pythonpath():
     """Does an $ENV_VAR get expanded in `spin run`?"""
     output = spin("run", "echo $PYTHONPATH")

--- a/spin/tests/test_build_cmds.py
+++ b/spin/tests/test_build_cmds.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from testutil import skip_on_windows, skip_unless_linux, spin, stderr, stdout
+from testutil import skip_on_windows, skip_unless_linux, spin, stdout
 
 from spin.cmds.util import run
 
@@ -47,28 +47,12 @@ def test_coverage_builds():
 )
 def test_coverage_reports(report_type, output_file):
     """Does gcov test generate coverage reports?"""
-    spin("test", "--gcov")
-    spin("test", "--gcov-report", report_type)
+    spin("test", "--gcov", f"--gcov-format={report_type}")
 
     coverage_report = Path("./build/meson-logs", output_file)
     assert (
         coverage_report.exists()
     ), f"coverage report not generated for gcov build ({report_type})"
-
-
-@pytest.mark.parametrize(
-    "command,error_message",
-    [
-        ("", "`build` folder not found"),
-        ("build", "debug build not found"),
-        ("test", "debug build not found"),
-    ],
-)
-def test_no_debug_coverage_attempt(command, error_message):
-    """Does gcov report throw error in case of missing debug files"""
-    spin(command) if command else None
-    output = spin("test", "--gcov-report", "html", sys_exit=False)
-    assert error_message in stderr(output)
 
 
 def test_expand_pythonpath():

--- a/spin/tests/test_build_cmds.py
+++ b/spin/tests/test_build_cmds.py
@@ -4,7 +4,8 @@ import sys
 import tempfile
 from pathlib import Path
 
-from testutil import skip_on_windows, skip_unless_linux, spin, stdout
+import pytest
+from testutil import skip_on_windows, skip_unless_linux, spin, stderr, stdout
 
 from spin.cmds.util import run
 


### PR DESCRIPTION
### Changes
- Added ``--gcov-report`` flag to ``spin test``

```sh
spin test --help                                                                                                    1 ↵ ganesh@ganesh-MS-7B86
Usage: spin test [OPTIONS] [PYTEST_ARGS]...
...
  --gcov-report [html|xml|text|sonarqube]
                                  Generate a coverage report for C Code and exit
...
```

### Testing
#### Happy Path
```py
» spin test --gcov
...
» spin test --gcov-report html                                                                                    ganesh@ganesh-MS-7B86
Verifying installed packages for generating coverage reports...
$ ninja -C build -t targets all
Generating html coverage report...
$ ninja -C build coverage-html
Coverage report generated successfully and written to /home/ganesh/os/devpy/example_pkg/build/meson-logs/coveragereport/index.html
```
#### Failures
1. No build found
```py
» git clean -xdf                                                                                                           ganesh@ganesh-MS-7B86
Removing .spin/__pycache__/
Removing build-install/
Removing build/
» spin test --generate-gcov-report html                                                                                    ganesh@ganesh-MS-7B86
Verifying installed packages for generating coverage reports...
Error: `build` folder not found, cannot generate coverage reports. Generate coverage artefacts by running `spin test --gcov`
```
2. Gcovr, etc not installed
```py
» spin test --gcov-report html                                                                                   ganesh@ganesh-MS-7B86
Verifying installed packages for generating coverage reports...
$ ninja -C build -t targets all
Error: coverage-html is not supported... Ensure the following are installed: Gcovr/GenHTML, lcov and rerun `spin test --gcov`
```

### Notes
#### ToDo

- [ ] UT

#### Misc
resolves https://github.com/scientific-python/spin/issues/158
continues https://github.com/scientific-python/spin/pull/146