### PR TITLE
Only add gcov flag when it's specified

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -433,7 +433,10 @@ def test(
         click.secho(
             "Invoking `build` prior to running tests:", bold=True, fg="bright_green"
         )
-        ctx.invoke(build_cmd, gcov=bool(gcov))
+        if gcov is not None:
+            ctx.invoke(build_cmd, gcov=bool(gcov))
+        else:
+            ctx.invoke(build_cmd)
 
     package = cfg.get("tool.spin.package", None)
     if (not pytest_args) and (not tests):


### PR DESCRIPTION
Solve problems running in environments without gcov.

Fix numpy tests on [x86-64, LP64 OpenBLAS (MSVC)](https://github.com/numpy/numpy/actions/runs/8966988031/job/24623596948?pr=26388#logs) and [x86-64, LP64 OpenBLAS (Clang-cl)](https://github.com/numpy/numpy/actions/runs/8966988031/job/24623597659?pr=26388#logs)

```
Run spin test
  spin test
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    pythonLocation: C:\hostedtoolcache\windows\Python\3.11.9\x64
    PKG_CONFIG_PATH: D:\a\numpy\numpy/.openblas
    Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.11.9\x64
    Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.11.9\x64
    Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.11.9\x64
Invoking `build` prior to running tests:
Error: build() got an unexpected keyword argument 'gcov'; aborting.
Error: Process completed with exit code 1.
```