### PR TITLE
Do not attempt to guess when the user is specifying tests

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -450,7 +450,7 @@ def test(
         )
         raise SystemExit(1)
 
-    if (not pytest_args) and (not tests):
+    if not tests:
         tests = package
 
     site_path = _set_pythonpath()


### PR DESCRIPTION
Those always need to use the `-k` flag. We cannot avoid setting `--pyargs`, otherwise src/ package layouts won't work.

Closes #204