### PR TITLE
FIX make sphinx docs work on Windows

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -857,7 +857,9 @@ def docs(
             bold=True,
             fg="bright_blue",
         )
-    _run(["make", "-C", doc_dir, sphinx_target], replace=True)
+
+    make_cmd = "make.bat" if sys.platform == "win32" else "make"
+    _run([make_cmd, sphinx_target], cwd=doc_dir, replace=True)
 
 
 @click.command()

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -858,7 +858,8 @@ def docs(
             fg="bright_blue",
         )
 
-    make_cmd = "make.bat" if sys.platform == "win32" else "make"
+    make_bat_exists = (Path(doc_dir) / "make.bat").exists()
+    make_cmd = "make.bat" if sys.platform == "win32" and make_bat_exists else "make"
     _run([make_cmd, sphinx_target], cwd=doc_dir, replace=True)
 
 


### PR DESCRIPTION
`make` does not exist on Windows in general so `spin docs` does not work on Windows.

This small patch seems to be a reasonable way to make it more likely than `spin docs` works on Windows. I tested this on a Windows VM and it seems to work fine. The debug information is useful as well (i.e. `cd doc` is explicitly mentioned):
```
> spin docs html-noplot
$ export SPHINXOPTS=-W -j auto
$ cd doc
$ make.bat html-noplot
```

As noted in https://github.com/scikit-learn/scikit-learn/pull/29012#issuecomment-2123418532 `make.bat` is generated by `sphinx-quickstart` and some projects still have it. scikit-learn has it and I think it is supposed to work, although we don't have that many developers on Windows. `numpy` and `matplotlib` still have `make.bat` as well.

Something else that I may take a closer look at one point in scikit-learn would be to actually not use the `Makefile` at all for most useful doc-related functionalities and implement them as spin custom command. This is probably a bit of work (in particular `doc/Makefile` has some quirks related to environment variables in CI and different OS) and not high-priority right now.