### PR TITLE
Improve spin docs error message when no build is found

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -861,7 +861,9 @@ def docs(
     try:
         site_path = _get_site_packages()
     except FileNotFoundError:
-        print("No built numpy found; run `spin build` first.")
+        cfg = get_config()
+        distname = cfg.get("project.name", None)
+        print(f"{distname} build not found; run `spin build` or `spin install` first.")
         sys.exit(1)
 
     opts = os.environ.get("SPHINXOPTS", "-W")


### PR DESCRIPTION
I don't think there is a way to detect which command to call between `spin build` and `spin install`. If you have no build you can not know whether the user intention is to use editable install or out-of-tree build.

I use `project.name` rather than `tool.spin.package` because it feels a bit more generic and appropriate but I could change it.