### PR TITLE
Make spin install verbose by default

### DIFF
--- a/spin/cmds/pip.py
+++ b/spin/cmds/pip.py
@@ -9,7 +9,12 @@ from .util import run as _run
     default=True,
     help="Install in editable mode.",
 )
-@click.option("-v", "--verbose", is_flag=True, help="Print detailed build output.")
+@click.option(
+    "-v/-q", "--verbose/--quiet",
+    is_flag=True,
+    default=True,
+    help="Print detailed build output."
+)
 @click.option(
     "--verbose-import/--no-verbose-import",
     is_flag=True,

--- a/spin/cmds/pip.py
+++ b/spin/cmds/pip.py
@@ -10,10 +10,11 @@ from .util import run as _run
     help="Install in editable mode.",
 )
 @click.option(
-    "-v/-q", "--verbose/--quiet",
+    "-v/-q",
+    "--verbose/--quiet",
     is_flag=True,
     default=True,
-    help="Print detailed build output."
+    help="Print detailed build output.",
 )
 @click.option(
     "--verbose-import/--no-verbose-import",


### PR DESCRIPTION
I guess because `spin` is a developer tool, using verbose output by default makes sense.

Personally I use `spin install -v` 99% of the time (the 1% is when I forget `-v`), I find it useful to monitor the compilation output when recompilation is needed and I get a bit frustrated when things takes a bit long (more than 5s say) without output. I am like "what is taking so much time", for example I forgot that I switched branch and recompilation is needed.

I haven't added any test yet but will look at it in case this seems like a reasonable idea.