### PR TITLE
Running test inside of LLDB doesn't seem to work as expected; undocument

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -466,10 +466,6 @@ def test(
 
       spin test -j auto
 
-    To run a test inside of LLDB:
-
-      spin lldb -- python -mspin test ...
-
     For more, see `pytest --help`.
     """  # noqa: E501
     cfg = get_config()


### PR DESCRIPTION
Closes #231

We'll re-introduce documentation, once we know how to do this properly.