### PR TITLE
Update `spin` to make it a drop in replacement of `scipy/dev.py`

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -319,12 +319,12 @@ def build(
             )
         return
 
-    meson_args = list(meson_args)
+    meson_args_setup = list(meson_args["setup"])
 
     if gcov:
-        meson_args = meson_args + ["-Db_coverage=true"]
+        meson_args_setup = meson_args_setup + ["-Db_coverage=true"]
 
-    setup_cmd = _meson_cli() + ["setup", build_dir, f"--prefix={prefix}"] + meson_args
+    setup_cmd = _meson_cli() + ["setup", build_dir, "--prefix=/usr"] + meson_args_setup
 
     if clean:
         print(f"Removing `{build_dir}`")
@@ -351,15 +351,19 @@ def build(
 
         # Any other conditions that warrant a reconfigure?
 
+    meson_args_compile = list(meson_args["compile"])
     compile_flags = ["-v"] if verbose else []
-    if jobs:
-        compile_flags += ["-j", str(jobs)]
+    if "jobs" in meson_args:
+        jobs = meson_args["jobs"]
+    compile_flags += ["-j", str(jobs)]
 
     p = _run(
-        _meson_cli() + ["compile"] + compile_flags + ["-C", build_dir],
+        _meson_cli() + ["compile"] + compile_flags + ["-C", build_dir] ,
         sys_exit=True,
         output=not quiet,
     )
+
+    meson_args_install = list(meson_args["install"])
     p = _run(
         _meson_cli()
         + [
@@ -371,7 +375,7 @@ def build(
             install_dir
             if os.path.isabs(install_dir)
             else os.path.relpath(abs_install_dir, abs_build_dir),
-        ],
+        ] + meson_args_install,
         output=(not quiet) and verbose,
     )
 

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -384,13 +384,7 @@ def build(
         ] + meson_args_install
 
     p = _run(
-         _meson_cli()
-         + [
-             "install",
-             "--only-changed",
-             "-C",
-             build_dir,
-             ] + meson_args_install,
+         cmd,
          output=(not quiet) and verbose,
      )
 

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -1,6 +1,5 @@
 import contextlib
 import copy
-import datetime
 import json
 import os
 import re
@@ -8,8 +7,6 @@ import shutil
 import sys
 from enum import Enum
 from pathlib import Path
-import subprocess
-import time
 
 import click
 

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -274,6 +274,8 @@ def build(
     quiet=False,
     build_dir=None,
     prefix=None,
+    meson_compile_args=tuple(),
+    meson_install_args=tuple(),
 ):
     """🔧 Build package with Meson/ninja
 
@@ -319,18 +321,7 @@ def build(
             )
         return
 
-    if isinstance(meson_args, tuple):
-        # for backwards compatibility because
-        # previously meson_args was a tuple.
-        # all the members of the meson_args tuple
-        # were passed to meson setup subcommand.
-        meson_args_ = {}
-        meson_args_["setup"] = meson_args
-        meson_args_["compile"] = tuple()
-        meson_args_["install"] = tuple()
-        meson_args = meson_args_
-
-    meson_args_setup = list(meson_args.get("setup", tuple()))
+    meson_args_setup = list(meson_args)
 
     if gcov:
         meson_args_setup = meson_args_setup + ["-Db_coverage=true"]
@@ -362,26 +353,24 @@ def build(
 
         # Any other conditions that warrant a reconfigure?
 
-    meson_args_compile = list(meson_args.get("compile", tuple()))
+    meson_compile_args = list(meson_compile_args)
     compile_flags = ["-v"] if verbose else []
-    if "jobs" in meson_args:
-        jobs = meson_args["jobs"]
     if jobs is not None:
         compile_flags += ["-j", str(jobs)]
 
     p = _run(
-        _meson_cli() + ["compile"] + compile_flags + ["-C", abs_build_dir] + meson_args_compile,
+        _meson_cli() + ["compile"] + compile_flags + ["-C", abs_build_dir] + meson_compile_args,
         sys_exit=True,
         output=not quiet,
     )
 
-    meson_args_install = list(meson_args.get("install", tuple()))
+    meson_install_args = list(meson_install_args)
     cmd = _meson_cli() + [
             "install",
             "--only-changed",
             "-C",
             build_dir
-        ] + meson_args_install
+        ] + meson_install_args
 
     p = _run(
          cmd,

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -322,13 +322,6 @@ def build(
             )
         return
 
-    if isinstance(meson_args, tuple):
-        meson_args_ = {}
-        meson_args_["setup"] = meson_args
-        meson_args_["compile"] = tuple()
-        meson_args_["install"] = tuple()
-        meson_args = meson_args_
-
     meson_args_setup = list(meson_args.get("setup", tuple()))
 
     if gcov:

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -992,7 +992,11 @@ def docs(
 
     make_bat_exists = (Path(doc_dir) / "make.bat").exists()
     make_cmd = "make.bat" if sys.platform == "win32" and make_bat_exists else "make"
-    _run([make_cmd, sphinx_target], cwd=doc_dir, replace=True)
+    cmds = [make_cmd, "-j", str(jobs), sphinx_target]
+    if jobs == "auto":
+        cmds = [make_cmd, "-j", sphinx_target]
+
+    _run(cmds, cwd=doc_dir, replace=True)
 
 
 @click.command()

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -322,6 +322,17 @@ def build(
             )
         return
 
+    if isinstance(meson_args, tuple):
+        # for backwards compatibility because
+        # previously meson_args was a tuple.
+        # all the members of the meson_args tuple
+        # were passed to meson setup subcommand.
+        meson_args_ = {}
+        meson_args_["setup"] = meson_args
+        meson_args_["compile"] = tuple()
+        meson_args_["install"] = tuple()
+        meson_args = meson_args_
+
     meson_args_setup = list(meson_args.get("setup", tuple()))
 
     if gcov:

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -375,52 +375,16 @@ def build(
             build_dir
         ] + meson_args_install
 
-    if "root" not in meson_args:
-        raise KeyError("Project root not specified.")
-
-    dirs_root = meson_args["root"]
-    log_filename = dirs_root / 'meson-install.log'
-    start_time = datetime.datetime.now()
-    cmd_str = ' '.join([str(p) for p in cmd])
-    if meson_args.get("show_build_log", False):
-        ret = subprocess.call(cmd, cwd=dirs_root)
-    else:
-        print("Installing, see meson-install.log...")
-        with open(log_filename, 'w') as log:
-            p = subprocess.Popen(cmd, stdout=log, stderr=log,
-                                    cwd=dirs_root)
-
-        try:
-            # Wait for it to finish, and print something to indicate the
-            # process is alive, but only if the log file has grown (to
-            # allow continuous integration environments kill a hanging
-            # process accurately if it produces no output)
-            last_blip = time.time()
-            last_log_size = os.stat(log_filename).st_size
-            while p.poll() is None:
-                time.sleep(0.5)
-                if time.time() - last_blip > 60:
-                    log_size = os.stat(log_filename).st_size
-                    if log_size > last_log_size:
-                        elapsed = datetime.datetime.now() - start_time
-                        print(f"    ... installation in progress ({elapsed} "
-                                "elapsed)")
-                        last_blip = time.time()
-                        last_log_size = log_size
-
-            ret = p.wait()
-        except:  # noqa: E722
-            p.terminate()
-            raise
-    elapsed = datetime.datetime.now() - start_time
-
-    if ret != 0:
-        if meson_args.get("show_build_log", False):
-            with open(log_filename) as f:
-                print(f.read())
-        print(f"Installation failed! ({elapsed} elapsed)")
-        sys.exit(1)
-
+    p = _run(
+         _meson_cli()
+         + [
+             "install",
+             "--only-changed",
+             "-C",
+             build_dir,
+             ] + meson_args_install,
+         output=(not quiet) and verbose,
+     )
 
 def _get_configured_command(command_name):
     command_groups = get_commands()


### PR DESCRIPTION
Regarding context - We are shifting to `spin` for building, testing SciPy. This PR is for updating `spin` to make it work with the SciPy building process. One explanation for the update is given below. That is significant. Rest for the smaller updates in `spin` I will provide explanation in the code review when I will complete the work.

In SciPy each step i.e., `compile`, `setup` and `install` needs arguments from `meson_args`. You can't pass everything from `meson_args` tuple directly into the first command. So I added 3 keys, `"compile"`, `"setup"` and `"install"` to differentiate which meson argument from SciPy to pass in which step.

Relevant PR from SciPy - https://github.com/scipy/scipy/pull/21674
~Relevant PR from NumPy - https://github.com/numpy/numpy/pull/27606~