### PR TITLE
Allow overriding --prefix in spin build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,24 +38,3 @@ jobs:
       - name: Tests PyTest
         run: |
           pipx run nox --forcecolor -s test
-
-  test-uv-python:
-    strategy:
-      matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
-      - run: |
-          uv python install ${{ matrix.python_version }}
-          uv venv --python ${{ matrix.python_version }}
-      - name: Install system dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gdb lcov
-      - name: Tests PyTest
-        run: |
-          pipx run nox --forcecolor -s test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
       - run: |
-          uv python install ${{ matrix.version }}
-          uv venv --python ${{ matrix.version }}
+          uv python install ${{ matrix.python_version }}
+          uv venv --python ${{ matrix.python_version }}
       - name: Install system dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,24 @@ jobs:
       - name: Tests PyTest
         run: |
           pipx run nox --forcecolor -s test
+
+  test-uv-python:
+    strategy:
+      matrix:
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: |
+          uv python install ${{ matrix.version }}
+          uv venv --python ${{ matrix.version }}
+      - name: Install system dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdb lcov
+      - name: Tests PyTest
+        run: |
+          pipx run nox --forcecolor -s test

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -229,6 +229,10 @@ def _check_coverage_tool_installation(coverage_type: GcovReportFormat, build_dir
             "and rerun `spin test --gcov`"
         )
 
+if sys.platform.startswith('win'):
+    DEFAULT_PREFIX="C:/"
+else:
+    DEFAULT_PREFIX="/usr"
 
 build_dir_option = click.option(
     "-C",
@@ -238,7 +242,6 @@ build_dir_option = click.option(
     envvar="SPIN_BUILD_DIR",
     help="Meson build directory; package is installed into './{build-dir}-install'.",
 )
-
 
 @click.command()
 @click.option("-j", "--jobs", help="Number of parallel tasks to launch", type=int)
@@ -251,6 +254,7 @@ build_dir_option = click.option(
     is_flag=True,
     help="Enable C code coverage using `gcov`. Use `spin test --gcov` to generate reports.",
 )
+@click.option("--prefix", help="The build prefix, passed directly to meson.", type=str, default=DEFAULT_PREFIX)
 @click.argument("meson_args", nargs=-1)
 @build_dir_option
 def build(
@@ -262,6 +266,7 @@ def build(
     gcov=False,
     quiet=False,
     build_dir=None,
+    prefix=None,
 ):
     """🔧 Build package with Meson/ninja
 
@@ -312,7 +317,7 @@ def build(
     if gcov:
         meson_args = meson_args + ["-Db_coverage=true"]
 
-    setup_cmd = _meson_cli() + ["setup", build_dir] + meson_args
+    setup_cmd = _meson_cli() + ["setup", build_dir, f"--prefix={prefix}"] + meson_args
 
     if clean:
         print(f"Removing `{build_dir}`")

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -312,7 +312,7 @@ def build(
     if gcov:
         meson_args = meson_args + ["-Db_coverage=true"]
 
-    setup_cmd = _meson_cli() + ["setup", build_dir, "--prefix=/usr"] + meson_args
+    setup_cmd = _meson_cli() + ["setup", build_dir] + meson_args
 
     if clean:
         print(f"Removing `{build_dir}`")

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -312,7 +312,7 @@ def build(
     if gcov:
         meson_args = meson_args + ["-Db_coverage=true"]
 
-    setup_cmd = _meson_cli() + ["setup", build_dir] + meson_args
+    setup_cmd = _meson_cli() + ["setup", build_dir, '--prefix=/usr'] + meson_args
 
     if clean:
         print(f"Removing `{build_dir}`")

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -229,10 +229,11 @@ def _check_coverage_tool_installation(coverage_type: GcovReportFormat, build_dir
             "and rerun `spin test --gcov`"
         )
 
-if sys.platform.startswith('win'):
-    DEFAULT_PREFIX="C:/"
+
+if sys.platform.startswith("win"):
+    DEFAULT_PREFIX = "C:/"
 else:
-    DEFAULT_PREFIX="/usr"
+    DEFAULT_PREFIX = "/usr"
 
 build_dir_option = click.option(
     "-C",
@@ -242,6 +243,7 @@ build_dir_option = click.option(
     envvar="SPIN_BUILD_DIR",
     help="Meson build directory; package is installed into './{build-dir}-install'.",
 )
+
 
 @click.command()
 @click.option("-j", "--jobs", help="Number of parallel tasks to launch", type=int)
@@ -254,7 +256,12 @@ build_dir_option = click.option(
     is_flag=True,
     help="Enable C code coverage using `gcov`. Use `spin test --gcov` to generate reports.",
 )
-@click.option("--prefix", help="The build prefix, passed directly to meson.", type=str, default=DEFAULT_PREFIX)
+@click.option(
+    "--prefix",
+    help="The build prefix, passed directly to meson.",
+    type=str,
+    default=DEFAULT_PREFIX,
+)
 @click.argument("meson_args", nargs=-1)
 @build_dir_option
 def build(

--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -312,7 +312,7 @@ def build(
     if gcov:
         meson_args = meson_args + ["-Db_coverage=true"]
 
-    setup_cmd = _meson_cli() + ["setup", build_dir, '--prefix=/usr'] + meson_args
+    setup_cmd = _meson_cli() + ["setup", build_dir] + meson_args
 
     if clean:
         print(f"Removing `{build_dir}`")

--- a/spin/tests/test_build_cmds.py
+++ b/spin/tests/test_build_cmds.py
@@ -34,6 +34,10 @@ def test_debug_builds():
     debug_files = Path(".").rglob("*.gcno")
     assert len(list(debug_files)) != 0, "debug files not generated for gcov build"
 
+def test_prefix_buiulds():
+    """does spin build --prefix create a build-install directory wiht the correct structure?"""
+    spin("build", "--prefix=/foobar/")
+    assert (Path("build-install") / Path("foobar")).exists()
 
 def test_coverage_builds():
     """Does gcov test generate coverage files?"""

--- a/spin/tests/test_build_cmds.py
+++ b/spin/tests/test_build_cmds.py
@@ -34,10 +34,12 @@ def test_debug_builds():
     debug_files = Path(".").rglob("*.gcno")
     assert len(list(debug_files)) != 0, "debug files not generated for gcov build"
 
-def test_prefix_buiulds():
-    """does spin build --prefix create a build-install directory wiht the correct structure?"""
+
+def test_prefix_builds():
+    """does spin build --prefix create a build-install directory with the correct structure?"""
     spin("build", "--prefix=/foobar/")
     assert (Path("build-install") / Path("foobar")).exists()
+
 
 def test_coverage_builds():
     """Does gcov test generate coverage files?"""


### PR DESCRIPTION
Fixes #240

This lets users override --prefix. Right now it's hard-coded, which leads to breakage on windows sometimes.