### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   test_spin:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/example_pkg_src/pyproject.toml
+++ b/example_pkg_src/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "example_pkg"
 version = "0.0dev0"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 description = "spin Example Package"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spin"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 description = "Developer tool for scientific Python libraries"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/spin/cmds/util.py
+++ b/spin/cmds/util.py
@@ -1,5 +1,5 @@
 from __future__ import (
-    annotations,  # noqa: F401  # TODO: remove once only >3.8 is supported
+    annotations,  # noqa: F401  # TODO: remove once only >3.14 is supported
 )
 
 import copy


### PR DESCRIPTION
Python 3.8 EOL was 2024-10-07
https://devguide.python.org/versions/