### PR TITLE
Improve traceback printout

### DIFF
--- a/spin/__main__.py
+++ b/spin/__main__.py
@@ -1,11 +1,11 @@
 import collections
 import importlib
 import importlib.util
-import inspect
 import os
 import pathlib
 import sys
 import textwrap
+import traceback
 from typing import Union
 
 import click
@@ -199,17 +199,16 @@ def main():
 
     try:
         group()
-    except Exception as e:
+    except Exception:
         click.secho(
-            textwrap.dedent(
-                f"""\
+            "\n" + "".join(traceback.format_exception(*sys.exc_info(), limit=-1)),
+            fg="red",
+            bold=True,
+            file=sys.stderr,
+        )
 
-            {type(e).__name__}: {e}
-
-            This exception was raised from:
-
-              {inspect.trace()[-1].filename}
-
+        click.secho(
+            textwrap.dedent(f"""\
             If you suspect this is a bug in `spin`, please file a report at:
 
               https://github.com/scientific-python/spin
@@ -218,9 +217,8 @@ def main():
 
               spin: {__version__}, package: {proj_name}
 
-            Aborting."""
-            ),
-            fg="red",
+            Aborting."""),
+            fg="yellow",
             bold=True,
             file=sys.stderr,
         )


### PR DESCRIPTION
Now, it prints the last frame of the traceback, in a different color from the message asking to report spin bugs if applicable.

See https://github.com/scipy/scipy/issues/22887#issuecomment-2834063005

![2025-04-30_21:01:09](https://github.com/user-attachments/assets/592da9ca-d046-4bd9-9d3d-1d4ec299df87)
