### PR TITLE
Allow wrapping test run in lldb

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -483,6 +483,11 @@ Which tests to run. Can be a module, function, class, or method:
     default="html",
     help=f"Format of the gcov report. Can be one of {', '.join(e.value for e in GcovReportFormat)}.",
 )
+@click.option(
+    "--lldb",
+    is_flag=True,
+    help="Run pytest via lldb.",
+)
 @build_option
 @build_dir_option
 @click.pass_context
@@ -496,6 +501,7 @@ def test(
     coverage=False,
     gcov=None,
     gcov_format=None,
+    lldb=False,
     build=None,
     build_dir=None,
 ):
@@ -631,6 +637,14 @@ def test(
         cmd = [sys.executable, "-P", "-m", "pytest"]
     else:
         cmd = ["pytest"]
+
+    if lldb:
+        cmd = [
+            "lldb",
+            "-O",
+            "settings set target.process.follow-fork-mode child",
+            "--",
+        ] + cmd
 
     install_dir = _get_install_dir(build_dir)
     if not os.path.exists(install_dir):


### PR DESCRIPTION
An experiment to see if we can wrap our test runs in lldb, instead of figuring out all the correct arguments to pass to lldb.

Closes https://github.com/scientific-python/spin/issues/255