### PR TITLE
Use sys.executable to run pip in the 'install' command.

### DIFF
--- a/spin/cmds/pip.py
+++ b/spin/cmds/pip.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 from .util import run as _run
@@ -37,7 +39,7 @@ def install(*, pip_args, editable, verbose, verbose_import):
       pip install . --no-build-isolation --editable --no-clean
     """
     pip_args = list(pip_args)
-    pip_cmd = ["pip", "install"]
+    pip_cmd = [sys.executable, "-m", "pip", "install"]
     pip_args += ["--no-build-isolation"]
 
     if editable:


### PR DESCRIPTION
When I install python from a source tarball with the standard `./configure` script, there is no executable entry point called `pip` (it is called `pip3`).

This change modifies how `pip` is run in the `install()` function so that `sys.executable` is used to run the `pip` module.