### PR TITLE
Pin upper version of click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-  "click",
+  "click>=8.2,<8.3",
   "tomli; python_version < '3.11'",
   "colorama; platform_system == 'Windows'",
   "importlib_metadata >= 7"


### PR DESCRIPTION
Avoids https://github.com/pallets/click/issues/3065 until we adjust to the 8.3 release of click.

This should fix CI for projects that use spin, like SciPy: https://github.com/scipy/scipy/issues/23642