### PR TITLE
Update RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,11 +20,11 @@ Example `version number`
       export REPO="spin"
       export LOG="CHANGELOG.md"
 
-- Autogenerate release notes
+- Autogenerate release notes:
 
       changelist ${ORG}/${REPO} v${PREVIOUS} main --version ${VERSION} --out ${VERSION}.md
 
-- Put the output of the above command at the top of `CHANGELOG.md`
+- Put the output of the above command at the top of `CHANGELOG.md`:
 
       cat ${VERSION}.md | cat - ${LOG} > temp && mv temp ${LOG}
 
@@ -37,7 +37,7 @@ Example `version number`
 
 - Tag the release in git:
 
-      git tag -s v${VERSION} -m "signed ${VERSION} tag"
+      git tag -a -s v${VERSION} -m "signed ${VERSION} tag"
 
   If you do not have a gpg key, use -u instead; it is important for
   Debian packaging that the tags are annotated
@@ -49,11 +49,14 @@ Example `version number`
   where `origin` is the name of the `github.com:scientific-python/spin`
   repository
 
-- Review the github release page:
+- Review the github tags page:
 
       https://github.com/scientific-python/spin/tags
 
-- Update `version` in `spin/__init__.py`.
+  and create a release. Paste the content of "${VERSION}.md" into the
+  release notes, apart from the title line starting with `#`.
+
+- Update `version` in `spin/__init__.py` to `0.Xrc0.dev0`.
 
 - Commit changes:
 


### PR DESCRIPTION
I had to do an urgent release this morning to address #293

I noticed that the instructions do not make annotated tags. This issue may also affect other projects using the same procedure.

For `spin`, we do not publish GH releases automatically from tag. Is this intentional, or  otherwise something we can fairly easily address?

/cc @jarrodmillman