### PR TITLE
Allow click 8.3.x series, excluding 8.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-  "click>=8,<8.3",
+  "click>=8,!=8.3.0,<8.4",
   "tomli; python_version < '3.11'",
   "colorama; platform_system == 'Windows'",
   "importlib_metadata >= 7"


### PR DESCRIPTION
Click 8.3.0 broke spin because Sentinel objects are now passed instead of defaults in some instances:

https://github.com/pallets/click/issues/3065

8.3.1 will include two workarounds:

https://github.com/pallets/click/issues/3065#issuecomment-3334011895

I suspect

https://github.com/pallets/click/pull/3068

will address our problem.